### PR TITLE
Add definitions

### DIFF
--- a/hdl/def.v
+++ b/hdl/def.v
@@ -18,5 +18,6 @@
 
 // Simulation definitions
 `define GBUFF_ADDR_BEGIN 12'hf00  // Simulate only 256 entries (3840~4095)
+`define GBUFF_ADDR_END   12'hfff
 
 `endif

--- a/hdl/def.v
+++ b/hdl/def.v
@@ -1,7 +1,7 @@
 `ifndef _DEF_V
 `define _DEF_V
 
-// Common Definitions
+// Common definitions
 `define DATA_WIDTH 16    // A data is a 16-bit fixed-point number
 `define WORD_WIDTH 128   // A word in global buffer has 8 of data
 `define ADDR_WIDTH 12    // Global buffer has 4096 entries
@@ -15,5 +15,8 @@
 `define DATA2 47:32
 `define DATA1 31:16
 `define DATA0 15:0
+
+// Simulation definitions
+`define BUFF_MAX_SIZE 12'h0ff  // Simulate only 256 entries is enough
 
 `endif

--- a/hdl/def.v
+++ b/hdl/def.v
@@ -17,6 +17,6 @@
 `define DATA0 15:0
 
 // Simulation definitions
-`define BUFF_MAX_SIZE 12'h0ff  // Simulate only 256 entries is enough
+`define GBUFF_ADDR_BEGIN 12'h00f  // Simulate only 256 entries is enough
 
 `endif

--- a/hdl/def.v
+++ b/hdl/def.v
@@ -1,0 +1,19 @@
+`ifndef _DEF_V
+`define _DEF_V
+
+// Common Definitions
+`define DATA_WIDTH 16    // A data is a 16-bit fixed-point number
+`define WORD_WIDTH 128   // A word in global buffer has 8 of data
+`define ADDR_WIDTH 12    // Global buffer has 4096 entries
+
+// Data positions in a word (little endian)
+`define DATA7 127:112
+`define DATA6 111:96
+`define DATA5 95:80
+`define DATA4 79:64
+`define DATA3 63:48
+`define DATA2 47:32
+`define DATA1 31:16
+`define DATA0 15:0
+
+`endif

--- a/hdl/def.v
+++ b/hdl/def.v
@@ -17,6 +17,6 @@
 `define DATA0 15:0
 
 // Simulation definitions
-`define GBUFF_ADDR_BEGIN 12'h00f  // Simulate only 256 entries is enough
+`define GBUFF_ADDR_BEGIN 12'hf00  // Simulate only 256 entries (3840~4095)
 
 `endif


### PR DESCRIPTION
I've added the general definitions since we've done some testing and calculation and can determine the data width finally.
- **data width**: 16 bits
- **word width**: 128 bits
- **address width**: 12 bits

Note that we'll use **little endian**, e.g., put `data0` in `word[15:0]` and `data7` in `word[127:112]`